### PR TITLE
petsc4py: fix on linux

### DIFF
--- a/nix/petsc4py.nix
+++ b/nix/petsc4py.nix
@@ -4,6 +4,7 @@
 , numpy
 , pip
 , petsc
+, cython
 , mpi
 , clang
 }:
@@ -23,6 +24,7 @@ buildPythonPackage rec {
 
   buildInputs = [
     petsc
+    cython
   ];
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Cython needs to be explicitly added on Linux